### PR TITLE
Fix less instructions & css import 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In this project we are going to be building a news feed reader. The goal is to h
 
 ### Preprocessor Setup
 
-  * Run `less-watch-compiler less css index.less` from the top level of the Newsfeed-Components folder. 
+  * Run `less-watch-compiler LESS css index.less` from the top level of the Newsfeed-Components folder. 
   * Open index.html in your browser
 
 ### Part 1: The Articles Component

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <title>Lambda School Newsfeed</title>
-    <link rel="stylesheet" type="text/css" media="screen" href="./CSS/index.css" />
+    <link rel="stylesheet" type="text/css" media="screen" href="./css/index.css" />
     <script src="./Menu/Menu.js" defer></script>
     <script src="./Article/Article.js" defer></script>
   </head>


### PR DESCRIPTION
these changes account for the facts that:

- the less directory in README instructions should be capitalized not lower-cased

- the css import in INDEX.HTML should pull from  lower-cased css directory